### PR TITLE
Point behaviour change

### DIFF
--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -14,6 +14,7 @@ export interface CanvasProps {
   canvasRef: React.RefObject<HTMLDivElement>;
   testPath?: PathTestPoint[];
   hoveredPointIndex?: number | null;
+  polygonHoverState?: 'none' | 'first-point' | 'existing-point';
   onMouseDown: (e: React.MouseEvent) => void;
   onMouseMove: (e: React.MouseEvent) => void;
   onMouseUp: () => void;
@@ -31,6 +32,7 @@ export const Canvas: React.FC<CanvasProps> = ({
   canvasRef,
   testPath,
   hoveredPointIndex,
+  polygonHoverState = 'none',
   onMouseDown,
   onMouseMove,
   onMouseUp,
@@ -41,7 +43,11 @@ export const Canvas: React.FC<CanvasProps> = ({
 
   const getCursor = () => {
     if (currentTool === 'path-tester') return 'crosshair';
-    if (currentTool === 'polygon') return 'crosshair';
+    if (currentTool === 'polygon') {
+      if (polygonHoverState === 'first-point') return 'pointer';
+      if (polygonHoverState === 'existing-point') return 'not-allowed';
+      return 'crosshair';
+    }
     if (isDragging) return 'grabbing';
     return 'grab';
   };

--- a/src/utils/shapeUtils.ts
+++ b/src/utils/shapeUtils.ts
@@ -111,7 +111,26 @@ export const getShapeDisplayName = (shapeType: ShapeType): string => {
   return displayNames[shapeType];
 };
 
-export const calculateShapeBounds = (shape: Shape): { 
+export const findNearbyPointOnShape = (
+  x: number,
+  y: number,
+  shape: Shape,
+  scale: number
+): { index: number; isFirstPoint: boolean } | null => {
+  const threshold = 15 / scale;
+
+  for (let i = 0; i < shape.points.length; i++) {
+    const point = shape.points[i];
+    const distance = Math.sqrt(Math.pow(point.x - x, 2) + Math.pow(point.y - y, 2));
+    if (distance <= threshold) {
+      return { index: i, isFirstPoint: i === 0 };
+    }
+  }
+
+  return null;
+};
+
+export const calculateShapeBounds = (shape: Shape): {
   minX: number; 
   minY: number; 
   maxX: number; 


### PR DESCRIPTION
When closing a polygon (> 3 points), user can:
1. Press Escape
2. Click on the first point created for the polygon

A not-allowed icon will be shown if user attempts to click on other points besides the first point.
